### PR TITLE
fix: use "--preview" instead of "--preview=true"

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -4314,7 +4314,7 @@ exports.findPoetry = findPoetry;
 function getPoetryArgs(inputs) {
     const args = ["--yes"];
     if (inputs.preview) {
-        args.push("--preview=true");
+        args.push("--preview");
     }
     if (inputs.version) {
         args.push(`--version=${inputs.version}`);

--- a/src/find.ts
+++ b/src/find.ts
@@ -44,7 +44,7 @@ function getPoetryArgs(inputs: Inputs): string[] {
   const args: string[] = ["--yes"]
 
   if (inputs.preview) {
-    args.push("--preview=true")
+    args.push("--preview")
   }
   if (inputs.version) {
     args.push(`--version=${inputs.version}`)


### PR DESCRIPTION
c.f. https://github.com/python-poetry/poetry#installation

`--preview=true` yields the following error, so this PR fix the error.

```Run Gr1N/setup-poetry@v2
/opt/hostedtoolcache/Python/3.8.5/x64/bin/python /home/runner/work/_temp/56807897-6785-4aaa-9836-d8f6919852fd --yes --preview=true
usage: 56807897-6785-4aaa-9836-d8f6919852fd [-h] [-p] [--version VERSION] [-f]
                                            [--no-modify-path] [-y]
                                            [--uninstall] [--file FILE]
56807897-6785-4aaa-9836-d8f6919852fd: error: argument -p/--preview: ignored explicit argument 'true'
##[error]The process '/opt/hostedtoolcache/Python/3.8.5/x64/bin/python' failed with exit code 2```