### PR TITLE
Update Node Version to v16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: Poetry version to use, if version is not provided then latest stable version will be used
     required: false
 runs:
-  using: node12
+  using: node16
   main: dist/index.js
 branding:
   icon: package


### PR DESCRIPTION
Resolves #31

Node v12 actions are now deprecated. This PR bumps the node version in action.yml to 'node16'.

After this change, all tests have passed and the action works on my own project, so I do not think any additional changes are required.